### PR TITLE
Update FastMath.cpp

### DIFF
--- a/lib/FastMath.cpp
+++ b/lib/FastMath.cpp
@@ -44,6 +44,9 @@ FastMath::ArcTangents::ArcTangents()
         for (auto x = Min; x < Max; ++x) {
             for (auto y = Min; y < Max; ++y) {
                 const auto t = ::atan2f(x, y);
+                if (t < 0) {
+                    t += TwoPI;
+                }
                 if constexpr (std::is_same_v<Field::AngleType, float>) {
                     v.at(x - Min).at(y - Min) = static_cast<Field::AngleType>(t);
                 }

--- a/lib/FastMath.cpp
+++ b/lib/FastMath.cpp
@@ -43,7 +43,7 @@ FastMath::ArcTangents::ArcTangents()
         static Values v;
         for (auto x = Min; x < Max; ++x) {
             for (auto y = Min; y < Max; ++y) {
-                const auto t = ::atan2f(x, y);
+                auto t = ::atan2f(x, y);
                 if (t < 0) {
                     t += TwoPI;
                 }


### PR DESCRIPTION
FastMath::rotateAngle() returns negative angles when atan2 returns negative values. FastMath::rotateAngle() should always return positive values I believe.